### PR TITLE
Create `skip` command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,8 @@ pub mod now;
 pub mod ping;
 #[cfg(feature = "audio")]
 pub mod play;
+#[cfg(feature = "audio")]
+pub mod skip;
 pub mod slap;
 pub mod urban;
 
@@ -27,6 +29,8 @@ pub use now::Now;
 pub use ping::Ping;
 #[cfg(feature = "audio")]
 pub use play::Play;
+#[cfg(feature = "audio")]
+pub use skip::Skip;
 pub use slap::Slap;
 pub use urban::Urban;
 
@@ -51,7 +55,7 @@ pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
         Slap::register(ctx)
     )?;
     #[cfg(feature = "audio")]
-    tokio::try_join!(Play::register(ctx), Now::register(ctx))?;
+    tokio::try_join!(Play::register(ctx), Now::register(ctx), Skip::register(ctx))?;
     Ok(())
 }
 

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -42,6 +42,7 @@ impl CadencyCommand for Play {
         debug!("Execute play command");
         let url_option = utils::voice::parse_valid_url(&command.data.options);
         if let Some(valid_url) = url_option {
+            utils::voice::create_deferred_response(ctx, command).await?;
             if let Ok((manager, guild_id, _channel_id)) = utils::voice::join(ctx, command).await {
                 let call = manager.get(guild_id).unwrap();
                 match utils::voice::add_song(call.clone(), valid_url.to_string()).await {
@@ -52,7 +53,7 @@ impl CadencyCommand for Play {
                             Event::Periodic(std::time::Duration::from_secs(30), None),
                             InactiveHandler { guild_id, manager },
                         );
-                        utils::create_response(
+                        utils::voice::edit_deferred_response(
                             ctx,
                             command,
                             &format!(
@@ -68,7 +69,7 @@ impl CadencyCommand for Play {
                     }
                     Err(err) => {
                         error!("Failed to add song to queue: {}", err);
-                        utils::create_response(
+                        utils::voice::edit_deferred_response(
                             ctx,
                             command,
                             ":x: **Could not add audio source to the queue!**",
@@ -77,8 +78,12 @@ impl CadencyCommand for Play {
                     }
                 }
             } else {
-                utils::create_response(ctx, command, ":x: **Could not join your voice channel**")
-                    .await?;
+                utils::voice::edit_deferred_response(
+                    ctx,
+                    command,
+                    ":x: **Could not join your voice channel**",
+                )
+                .await?;
             }
         } else {
             utils::create_response(ctx, command, ":x: **This doesn't look lik a valid url**")

--- a/src/commands/skip.rs
+++ b/src/commands/skip.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "audio")]
+use crate::commands::CadencyCommand;
+use crate::error::CadencyError;
+use crate::utils;
+use serenity::{
+    async_trait,
+    client::Context,
+    model::application::{
+        command::Command, interaction::application_command::ApplicationCommandInteraction,
+    },
+};
+
+pub struct Skip;
+
+#[async_trait]
+impl CadencyCommand for Skip {
+    async fn register(ctx: &Context) -> Result<Command, serenity::Error> {
+        Ok(
+            Command::create_global_application_command(&ctx.http, |command| {
+                command.name("skip").description("Skip current song")
+            })
+            .await?,
+        )
+    }
+
+    async fn execute<'a>(
+        ctx: &Context,
+        command: &'a mut ApplicationCommandInteraction,
+    ) -> Result<(), CadencyError> {
+        debug!("Execute skip command");
+        if let Some(guild_id) = command.guild_id {
+            utils::voice::create_deferred_response(ctx, command).await?;
+            let manager = utils::voice::get_songbird(ctx).await;
+            if let Some(call) = manager.get(guild_id) {
+                let handler = call.lock().await;
+                if handler.queue().is_empty() {
+                    utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to skip**")
+                        .await?;
+                } else {
+                    match handler.queue().skip() {
+                        Ok(_) => {
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":fast_forward: **Skipped current song**",
+                            )
+                            .await?;
+                        }
+                        Err(err) => {
+                            error!("Failed to skip: {err:?}");
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":x: **Could not skip**",
+                            )
+                            .await?;
+                        }
+                    };
+                }
+            } else {
+                utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to skip**")
+                    .await?;
+            }
+        } else {
+            utils::create_response(
+                ctx,
+                command,
+                ":x: **This command can only be executed on a server**",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}

--- a/src/handler/command.rs
+++ b/src/handler/command.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     command_not_implemented, setup_commands, CadencyCommand, Fib, Inspire, Ping, Slap, Urban,
 };
 #[cfg(feature = "audio")]
-use crate::commands::{Now, Play};
+use crate::commands::{Now, Play, Skip};
 use crate::utils::set_bot_presence;
 
 pub struct Handler;
@@ -40,6 +40,8 @@ impl EventHandler for Handler {
                 "play" => Play::execute(&ctx, &mut command).await,
                 #[cfg(feature = "audio")]
                 "now" => Now::execute(&ctx, &mut command).await,
+                #[cfg(feature = "audio")]
+                "skip" => Skip::execute(&ctx, &mut command).await,
                 _ => command_not_implemented(&ctx, command).await,
             };
             if let Err(execution_err) = cmd_execution {


### PR DESCRIPTION
This PR creates and registers the `skip` slash command. Further an bug is fixed that sometimes lead to timeouts during the `play` command execution.

Close #9 
Close #10 