### PR TITLE
Prepare v0.2.0-rc.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadency"
-version = "0.1.1"
+version = "0.2.0-rc.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,5 @@ version = "1.0.130"
 features = ["derive"]
 
 [features]
+default = ["audio"]
 audio = ["songbird", "songbird/builtin-queue", "serenity/voice", "serenity/cache"]


### PR DESCRIPTION
This PR enables `audio` as default feature and bumps the version to v0.2.0-rc.1 .
