### PR TITLE
Release v0.2.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadency"
-version = "0.1.1"
+version = "0.2.0-rc.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -29,4 +29,5 @@ version = "1.0.130"
 features = ["derive"]
 
 [features]
+default = ["audio"]
 audio = ["songbird", "songbird/builtin-queue", "serenity/voice", "serenity/cache"]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,8 @@ pub mod fib;
 pub mod inspire;
 #[cfg(feature = "audio")]
 pub mod now;
+#[cfg(feature = "audio")]
+pub mod pause;
 pub mod ping;
 #[cfg(feature = "audio")]
 pub mod play;
@@ -26,6 +28,8 @@ pub use fib::Fib;
 pub use inspire::Inspire;
 #[cfg(feature = "audio")]
 pub use now::Now;
+#[cfg(feature = "audio")]
+pub use pause::Pause;
 pub use ping::Ping;
 #[cfg(feature = "audio")]
 pub use play::Play;
@@ -55,7 +59,12 @@ pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
         Slap::register(ctx)
     )?;
     #[cfg(feature = "audio")]
-    tokio::try_join!(Play::register(ctx), Now::register(ctx), Skip::register(ctx))?;
+    tokio::try_join!(
+        Play::register(ctx),
+        Now::register(ctx),
+        Skip::register(ctx),
+        Pause::register(ctx)
+    )?;
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,6 +24,8 @@ pub mod resume;
 #[cfg(feature = "audio")]
 pub mod skip;
 pub mod slap;
+#[cfg(feature = "audio")]
+pub mod stop;
 pub mod urban;
 
 pub use fib::Fib;
@@ -40,6 +42,8 @@ pub use resume::Resume;
 #[cfg(feature = "audio")]
 pub use skip::Skip;
 pub use slap::Slap;
+#[cfg(feature = "audio")]
+pub use stop::Stop;
 pub use urban::Urban;
 
 #[async_trait]
@@ -68,7 +72,8 @@ pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
         Now::register(ctx),
         Skip::register(ctx),
         Pause::register(ctx),
-        Resume::register(ctx)
+        Resume::register(ctx),
+        Stop::register(ctx)
     )?;
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,8 @@ pub mod skip;
 pub mod slap;
 #[cfg(feature = "audio")]
 pub mod stop;
+#[cfg(feature = "audio")]
+pub mod tracks;
 pub mod urban;
 
 pub use fib::Fib;
@@ -44,6 +46,8 @@ pub use skip::Skip;
 pub use slap::Slap;
 #[cfg(feature = "audio")]
 pub use stop::Stop;
+#[cfg(feature = "audio")]
+pub use tracks::Tracks;
 pub use urban::Urban;
 
 #[async_trait]
@@ -57,7 +61,7 @@ pub trait CadencyCommand {
 
 /// Submit global slash commands to the discord api.
 /// As global commands are cached for 1 hour, the activation ca take some time.
-/// For local testing it is recommended to create commandswith a guild scope.
+/// For local testing it is recommended to create commands with a guild scope.
 pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
     tokio::try_join!(
         Ping::register(ctx),
@@ -73,7 +77,8 @@ pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
         Skip::register(ctx),
         Pause::register(ctx),
         Resume::register(ctx),
-        Stop::register(ctx)
+        Stop::register(ctx),
+        Tracks::register(ctx)
     )?;
     Ok(())
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,6 +17,8 @@ pub mod now;
 pub mod ping;
 #[cfg(feature = "audio")]
 pub mod play;
+#[cfg(feature = "audio")]
+pub mod skip;
 pub mod slap;
 pub mod urban;
 
@@ -27,6 +29,8 @@ pub use now::Now;
 pub use ping::Ping;
 #[cfg(feature = "audio")]
 pub use play::Play;
+#[cfg(feature = "audio")]
+pub use skip::Skip;
 pub use slap::Slap;
 pub use urban::Urban;
 
@@ -51,7 +55,7 @@ pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
         Slap::register(ctx)
     )?;
     #[cfg(feature = "audio")]
-    tokio::try_join!(Play::register(ctx), Now::register(ctx))?;
+    tokio::try_join!(Play::register(ctx), Now::register(ctx), Skip::register(ctx))?;
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,6 +20,8 @@ pub mod ping;
 #[cfg(feature = "audio")]
 pub mod play;
 #[cfg(feature = "audio")]
+pub mod resume;
+#[cfg(feature = "audio")]
 pub mod skip;
 pub mod slap;
 pub mod urban;
@@ -33,6 +35,8 @@ pub use pause::Pause;
 pub use ping::Ping;
 #[cfg(feature = "audio")]
 pub use play::Play;
+#[cfg(feature = "audio")]
+pub use resume::Resume;
 #[cfg(feature = "audio")]
 pub use skip::Skip;
 pub use slap::Slap;
@@ -63,7 +67,8 @@ pub async fn setup_commands(ctx: &Context) -> Result<(), serenity::Error> {
         Play::register(ctx),
         Now::register(ctx),
         Skip::register(ctx),
-        Pause::register(ctx)
+        Pause::register(ctx),
+        Resume::register(ctx)
     )?;
     Ok(())
 }

--- a/src/commands/pause.rs
+++ b/src/commands/pause.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "audio")]
+use crate::commands::CadencyCommand;
+use crate::error::CadencyError;
+use crate::utils;
+use serenity::{
+    async_trait,
+    client::Context,
+    model::application::{
+        command::Command, interaction::application_command::ApplicationCommandInteraction,
+    },
+};
+
+pub struct Pause;
+
+#[async_trait]
+impl CadencyCommand for Pause {
+    async fn register(ctx: &Context) -> Result<Command, serenity::Error> {
+        Ok(
+            Command::create_global_application_command(&ctx.http, |command| {
+                command.name("pause").description("Pause current song")
+            })
+            .await?,
+        )
+    }
+
+    async fn execute<'a>(
+        ctx: &Context,
+        command: &'a mut ApplicationCommandInteraction,
+    ) -> Result<(), CadencyError> {
+        debug!("Execute pause command");
+        if let Some(guild_id) = command.guild_id {
+            utils::voice::create_deferred_response(ctx, command).await?;
+            let manager = utils::voice::get_songbird(ctx).await;
+            if let Some(call) = manager.get(guild_id) {
+                let handler = call.lock().await;
+                if handler.queue().is_empty() {
+                    utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to pause**")
+                        .await?;
+                } else {
+                    match handler.queue().pause() {
+                        Ok(_) => {
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":pause_button: **Paused**",
+                            )
+                            .await?;
+                        }
+                        Err(err) => {
+                            error!("Failed to pause: {err:?}");
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":x: **Could not pause**",
+                            )
+                            .await?;
+                        }
+                    };
+                }
+            } else {
+                utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to pause**")
+                    .await?;
+            }
+        } else {
+            utils::create_response(
+                ctx,
+                command,
+                ":x: **This command can only be executed on a server**",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -42,6 +42,7 @@ impl CadencyCommand for Play {
         debug!("Execute play command");
         let url_option = utils::voice::parse_valid_url(&command.data.options);
         if let Some(valid_url) = url_option {
+            utils::voice::create_deferred_response(ctx, command).await?;
             if let Ok((manager, guild_id, _channel_id)) = utils::voice::join(ctx, command).await {
                 let call = manager.get(guild_id).unwrap();
                 match utils::voice::add_song(call.clone(), valid_url.to_string()).await {
@@ -52,7 +53,7 @@ impl CadencyCommand for Play {
                             Event::Periodic(std::time::Duration::from_secs(30), None),
                             InactiveHandler { guild_id, manager },
                         );
-                        utils::create_response(
+                        utils::voice::edit_deferred_response(
                             ctx,
                             command,
                             &format!(
@@ -68,7 +69,7 @@ impl CadencyCommand for Play {
                     }
                     Err(err) => {
                         error!("Failed to add song to queue: {}", err);
-                        utils::create_response(
+                        utils::voice::edit_deferred_response(
                             ctx,
                             command,
                             ":x: **Could not add audio source to the queue!**",
@@ -77,8 +78,12 @@ impl CadencyCommand for Play {
                     }
                 }
             } else {
-                utils::create_response(ctx, command, ":x: **Could not join your voice channel**")
-                    .await?;
+                utils::voice::edit_deferred_response(
+                    ctx,
+                    command,
+                    ":x: **Could not join your voice channel**",
+                )
+                .await?;
             }
         } else {
             utils::create_response(ctx, command, ":x: **This doesn't look lik a valid url**")

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -50,7 +50,7 @@ impl CadencyCommand for Play {
                         let mut handler = call.lock().await;
                         handler.remove_all_global_events();
                         handler.add_global_event(
-                            Event::Periodic(std::time::Duration::from_secs(30), None),
+                            Event::Periodic(std::time::Duration::from_secs(120), None),
                             InactiveHandler { guild_id, manager },
                         );
                         utils::voice::edit_deferred_response(

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1,0 +1,76 @@
+#![cfg(feature = "audio")]
+use crate::commands::CadencyCommand;
+use crate::error::CadencyError;
+use crate::utils;
+use serenity::{
+    async_trait,
+    client::Context,
+    model::application::{
+        command::Command, interaction::application_command::ApplicationCommandInteraction,
+    },
+};
+
+pub struct Resume;
+
+#[async_trait]
+impl CadencyCommand for Resume {
+    async fn register(ctx: &Context) -> Result<Command, serenity::Error> {
+        Ok(
+            Command::create_global_application_command(&ctx.http, |command| {
+                command
+                    .name("resume")
+                    .description("Resume current song if paused")
+            })
+            .await?,
+        )
+    }
+
+    async fn execute<'a>(
+        ctx: &Context,
+        command: &'a mut ApplicationCommandInteraction,
+    ) -> Result<(), CadencyError> {
+        debug!("Execute skip command");
+        if let Some(guild_id) = command.guild_id {
+            utils::voice::create_deferred_response(ctx, command).await?;
+            let manager = utils::voice::get_songbird(ctx).await;
+            if let Some(call) = manager.get(guild_id) {
+                let handler = call.lock().await;
+                if handler.queue().is_empty() {
+                    utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to resume**")
+                        .await?;
+                } else {
+                    match handler.queue().resume() {
+                        Ok(_) => {
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":play_pause: **Resumed**",
+                            )
+                            .await?;
+                        }
+                        Err(err) => {
+                            error!("Failed to resume: {err:?}");
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":x: **Could not resume**",
+                            )
+                            .await?;
+                        }
+                    };
+                }
+            } else {
+                utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to resume**")
+                    .await?;
+            }
+        } else {
+            utils::create_response(
+                ctx,
+                command,
+                ":x: **This command can only be executed on a server**",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}

--- a/src/commands/skip.rs
+++ b/src/commands/skip.rs
@@ -1,0 +1,74 @@
+#![cfg(feature = "audio")]
+use crate::commands::CadencyCommand;
+use crate::error::CadencyError;
+use crate::utils;
+use serenity::{
+    async_trait,
+    client::Context,
+    model::application::{
+        command::Command, interaction::application_command::ApplicationCommandInteraction,
+    },
+};
+
+pub struct Skip;
+
+#[async_trait]
+impl CadencyCommand for Skip {
+    async fn register(ctx: &Context) -> Result<Command, serenity::Error> {
+        Ok(
+            Command::create_global_application_command(&ctx.http, |command| {
+                command.name("skip").description("Skip current song")
+            })
+            .await?,
+        )
+    }
+
+    async fn execute<'a>(
+        ctx: &Context,
+        command: &'a mut ApplicationCommandInteraction,
+    ) -> Result<(), CadencyError> {
+        debug!("Execute skip command");
+        if let Some(guild_id) = command.guild_id {
+            utils::voice::create_deferred_response(ctx, command).await?;
+            let manager = utils::voice::get_songbird(ctx).await;
+            if let Some(call) = manager.get(guild_id) {
+                let handler = call.lock().await;
+                if handler.queue().is_empty() {
+                    utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to skip**")
+                        .await?;
+                } else {
+                    match handler.queue().skip() {
+                        Ok(_) => {
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":fast_forward: **Skipped current song**",
+                            )
+                            .await?;
+                        }
+                        Err(err) => {
+                            error!("Failed to skip: {err:?}");
+                            utils::voice::edit_deferred_response(
+                                ctx,
+                                command,
+                                ":x: **Could not skip**",
+                            )
+                            .await?;
+                        }
+                    };
+                }
+            } else {
+                utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to skip**")
+                    .await?;
+            }
+        } else {
+            utils::create_response(
+                ctx,
+                command,
+                ":x: **This command can only be executed on a server**",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}

--- a/src/commands/stop.rs
+++ b/src/commands/stop.rs
@@ -1,0 +1,64 @@
+#![cfg(feature = "audio")]
+use crate::commands::CadencyCommand;
+use crate::error::CadencyError;
+use crate::utils;
+use serenity::{
+    async_trait,
+    client::Context,
+    model::application::{
+        command::Command, interaction::application_command::ApplicationCommandInteraction,
+    },
+};
+
+pub struct Stop;
+
+#[async_trait]
+impl CadencyCommand for Stop {
+    async fn register(ctx: &Context) -> Result<Command, serenity::Error> {
+        Ok(
+            Command::create_global_application_command(&ctx.http, |command| {
+                command
+                    .name("stop")
+                    .description("Stop music and clean up the track list")
+            })
+            .await?,
+        )
+    }
+
+    async fn execute<'a>(
+        ctx: &Context,
+        command: &'a mut ApplicationCommandInteraction,
+    ) -> Result<(), CadencyError> {
+        debug!("Execute stop command");
+        if let Some(guild_id) = command.guild_id {
+            utils::voice::create_deferred_response(ctx, command).await?;
+            let manager = utils::voice::get_songbird(ctx).await;
+            if let Some(call) = manager.get(guild_id) {
+                let handler = call.lock().await;
+                if handler.queue().is_empty() {
+                    utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to stop**")
+                        .await?;
+                } else {
+                    handler.queue().stop();
+                    utils::voice::edit_deferred_response(
+                        ctx,
+                        command,
+                        ":white_check_mark: :wastebasket: **Successfully stopped and cleared the playlist**",
+                    )
+                    .await?;
+                }
+            } else {
+                utils::voice::edit_deferred_response(ctx, command, ":x: **Nothing to stop**")
+                    .await?;
+            }
+        } else {
+            utils::create_response(
+                ctx,
+                command,
+                ":x: **This command can only be executed on a server**",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}

--- a/src/commands/tracks.rs
+++ b/src/commands/tracks.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "audio")]
+use crate::commands::CadencyCommand;
+use crate::error::CadencyError;
+use crate::utils;
+use serenity::{
+    async_trait,
+    builder::CreateEmbed,
+    client::Context,
+    model::application::{
+        command::Command, interaction::application_command::ApplicationCommandInteraction,
+    },
+    utils::Color,
+};
+
+pub struct Tracks;
+
+#[async_trait]
+impl CadencyCommand for Tracks {
+    async fn register(ctx: &Context) -> Result<Command, serenity::Error> {
+        Ok(
+            Command::create_global_application_command(&ctx.http, |command| {
+                command
+                    .name("tracks")
+                    .description("List all tracks in the queue")
+            })
+            .await?,
+        )
+    }
+
+    async fn execute<'a>(
+        ctx: &Context,
+        command: &'a mut ApplicationCommandInteraction,
+    ) -> Result<(), CadencyError> {
+        debug!("Execute tracks command");
+        if let Some(guild_id) = command.guild_id {
+            utils::voice::create_deferred_response(ctx, command).await?;
+            let manager = utils::voice::get_songbird(ctx).await;
+            if let Some(call) = manager.get(guild_id) {
+                let handler = call.lock().await;
+                if handler.queue().is_empty() {
+                    utils::voice::edit_deferred_response(
+                        ctx,
+                        command,
+                        ":x: **No tracks in the queue**",
+                    )
+                    .await?;
+                } else {
+                    let queue_snapshot = handler.queue().current_queue();
+                    let mut embeded_tracks = CreateEmbed::default();
+                    embeded_tracks.color(Color::BLURPLE);
+                    embeded_tracks.title("Track List");
+                    for (index, track) in queue_snapshot.into_iter().enumerate() {
+                        let position = index + 1;
+                        let metadata = track.metadata();
+                        let title = metadata
+                            .title
+                            .as_ref()
+                            .map_or("**No title provided**", |t| t);
+                        let url = metadata
+                            .source_url
+                            .as_ref()
+                            .map_or("**No url provided**", |u| u);
+                        embeded_tracks.field(
+                            format!("{position}. :newspaper: `{title}`"),
+                            format!(":notes: `${url}`"),
+                            false,
+                        );
+                    }
+                    utils::voice::edit_deferred_response_with_embeded(ctx, command, embeded_tracks)
+                        .await?;
+                }
+            } else {
+                utils::voice::edit_deferred_response(
+                    ctx,
+                    command,
+                    ":x: **No tracks in the queue**",
+                )
+                .await?;
+            }
+        } else {
+            utils::create_response(
+                ctx,
+                command,
+                ":x: **This command can only be executed on a server**",
+            )
+            .await?;
+        }
+        Ok(())
+    }
+}

--- a/src/handler/command.rs
+++ b/src/handler/command.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     command_not_implemented, setup_commands, CadencyCommand, Fib, Inspire, Ping, Slap, Urban,
 };
 #[cfg(feature = "audio")]
-use crate::commands::{Now, Pause, Play, Skip};
+use crate::commands::{Now, Pause, Play, Resume, Skip};
 use crate::utils::set_bot_presence;
 
 pub struct Handler;
@@ -44,6 +44,8 @@ impl EventHandler for Handler {
                 "skip" => Skip::execute(&ctx, &mut command).await,
                 #[cfg(feature = "audio")]
                 "pause" => Pause::execute(&ctx, &mut command).await,
+                #[cfg(feature = "audio")]
+                "resume" => Resume::execute(&ctx, &mut command).await,
                 _ => command_not_implemented(&ctx, command).await,
             };
             if let Err(execution_err) = cmd_execution {

--- a/src/handler/command.rs
+++ b/src/handler/command.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     command_not_implemented, setup_commands, CadencyCommand, Fib, Inspire, Ping, Slap, Urban,
 };
 #[cfg(feature = "audio")]
-use crate::commands::{Now, Pause, Play, Resume, Skip, Stop};
+use crate::commands::{Now, Pause, Play, Resume, Skip, Stop, Tracks};
 use crate::utils::set_bot_presence;
 
 pub struct Handler;
@@ -18,6 +18,7 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, _data_about_bot: Ready) {
         info!("🚀 Start Cadency Discord Bot");
         set_bot_presence(&ctx).await;
+        info!("⏳ Started to submit commands, please wait...");
         match setup_commands(&ctx).await {
             Ok(_) => info!("✅ Application commands submitted"),
             Err(err) => error!("❌ Failed to submit application commands: {:?}", err),
@@ -48,6 +49,8 @@ impl EventHandler for Handler {
                 "resume" => Resume::execute(&ctx, &mut command).await,
                 #[cfg(feature = "audio")]
                 "stop" => Stop::execute(&ctx, &mut command).await,
+                #[cfg(feature = "audio")]
+                "tracks" => Tracks::execute(&ctx, &mut command).await,
                 _ => command_not_implemented(&ctx, command).await,
             };
             if let Err(execution_err) = cmd_execution {

--- a/src/handler/command.rs
+++ b/src/handler/command.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     command_not_implemented, setup_commands, CadencyCommand, Fib, Inspire, Ping, Slap, Urban,
 };
 #[cfg(feature = "audio")]
-use crate::commands::{Now, Play, Skip};
+use crate::commands::{Now, Pause, Play, Skip};
 use crate::utils::set_bot_presence;
 
 pub struct Handler;
@@ -42,6 +42,8 @@ impl EventHandler for Handler {
                 "now" => Now::execute(&ctx, &mut command).await,
                 #[cfg(feature = "audio")]
                 "skip" => Skip::execute(&ctx, &mut command).await,
+                #[cfg(feature = "audio")]
+                "pause" => Pause::execute(&ctx, &mut command).await,
                 _ => command_not_implemented(&ctx, command).await,
             };
             if let Err(execution_err) = cmd_execution {

--- a/src/handler/command.rs
+++ b/src/handler/command.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     command_not_implemented, setup_commands, CadencyCommand, Fib, Inspire, Ping, Slap, Urban,
 };
 #[cfg(feature = "audio")]
-use crate::commands::{Now, Pause, Play, Resume, Skip};
+use crate::commands::{Now, Pause, Play, Resume, Skip, Stop};
 use crate::utils::set_bot_presence;
 
 pub struct Handler;
@@ -46,6 +46,8 @@ impl EventHandler for Handler {
                 "pause" => Pause::execute(&ctx, &mut command).await,
                 #[cfg(feature = "audio")]
                 "resume" => Resume::execute(&ctx, &mut command).await,
+                #[cfg(feature = "audio")]
+                "stop" => Stop::execute(&ctx, &mut command).await,
                 _ => command_not_implemented(&ctx, command).await,
             };
             if let Err(execution_err) = cmd_execution {

--- a/src/handler/command.rs
+++ b/src/handler/command.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     command_not_implemented, setup_commands, CadencyCommand, Fib, Inspire, Ping, Slap, Urban,
 };
 #[cfg(feature = "audio")]
-use crate::commands::{Now, Play};
+use crate::commands::{Now, Play, Skip};
 use crate::utils::set_bot_presence;
 
 pub struct Handler;
@@ -40,6 +40,8 @@ impl EventHandler for Handler {
                 "play" => Play::execute(&ctx, &mut command).await,
                 #[cfg(feature = "audio")]
                 "now" => Now::execute(&ctx, &mut command).await,
+                #[cfg(feature = "audio")]
+                "skip" => Skip::execute(&ctx, &mut command).await,
                 _ => command_not_implemented(&ctx, command).await,
             };
             if let Err(execution_err) = cmd_execution {

--- a/src/utils/voice.rs
+++ b/src/utils/voice.rs
@@ -4,6 +4,7 @@ use crate::utils;
 use reqwest::Url;
 use serenity::model;
 use serenity::{
+    builder::CreateEmbed,
     client::Context,
     model::application::interaction::{
         application_command::{
@@ -105,7 +106,7 @@ pub async fn create_deferred_response<'a>(
         })
         .await
         .map_err(|err| {
-            error!("Failed to submit deferred message: {}", err);
+            error!("Failed to submit deferred message: {err}");
             CadencyError::Response
         })
 }
@@ -121,7 +122,24 @@ pub async fn edit_deferred_response<'a>(
         })
         .await
         .map_err(|err| {
-            error!("Failed to edit deferred message: {}", err);
+            error!("Failed to edit deferred message: {err}");
+            CadencyError::Response
+        })?;
+    Ok(())
+}
+
+pub async fn edit_deferred_response_with_embeded<'a>(
+    ctx: &Context,
+    interaction: &mut ApplicationCommandInteraction,
+    embeded_content: CreateEmbed,
+) -> Result<(), CadencyError> {
+    interaction
+        .edit_original_interaction_response(&ctx.http, |previous_response| {
+            previous_response.set_embed(embeded_content)
+        })
+        .await
+        .map_err(|err| {
+            error!("Failed to edit deferred message with embeded content: {err}");
             CadencyError::Response
         })?;
     Ok(())


### PR DESCRIPTION
- refactor(utils): Create deferred response helper
- fix(play): Use deferred responses to avoid timeouts
- feat(skip): Create and register skip command
- feat(pause): Create and register pause command
- feat(resume): Create and register resumse command
- feat(stop): Create and register stop slash command
- feat(play): Increase idle time to 2 mins
- feat(tracks): Create and register tracks command
- chore: Improve logging on registering commands
- chore(cargo): Add  feature as default feature
- chore(cargo): Bump version to v0.2.0-rc.1
