### PR TITLE
Set `info` as default logging strategy

### DIFF
--- a/cadency/src/main.rs
+++ b/cadency/src/main.rs
@@ -10,7 +10,8 @@ use cadency_core::Cadency;
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
+    let env = env_logger::Env::default().filter_or("RUST_LOG", "cadency=info");
+    env_logger::init_from_env(env);
 
     let commands = setup_commands![
         Fib::default(),


### PR DESCRIPTION
This PR set `info` as default logging strategy to prevent that the bot doesn't show any output if no `RUST_LOG` environment variable is defined. 