### PR TITLE
Generate command arguments with macro

### DIFF
--- a/cadency_codegen/Cargo.toml
+++ b/cadency_codegen/Cargo.toml
@@ -12,5 +12,6 @@ proc_macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proc-macro2 = "1.0.51"
 quote = "1.0.23"
 syn = "1.0.107"

--- a/cadency_codegen/src/derive.rs
+++ b/cadency_codegen/src/derive.rs
@@ -1,58 +1,142 @@
 use proc_macro::TokenStream;
-use syn::{DeriveInput, Lit, Meta};
+use syn::{DeriveInput, Lit, Meta, NestedMeta};
 
 pub(crate) fn impl_command_baseline(derive_input: DeriveInput) -> TokenStream {
     let struct_name = derive_input.ident;
     let mut command_name = struct_name.to_string().to_lowercase();
     let mut description = "".to_string();
     let mut deferred = false;
+    let mut arguments: Vec<(String, String, String, bool)> = vec![];
     for attr in derive_input.attrs.iter() {
         let attr_meta = attr.parse_meta().unwrap();
-        if let Meta::NameValue(derive_attr) = attr_meta {
-            match derive_attr.path.get_ident().unwrap().to_string().as_str() {
-                "name" => {
-                    if let Lit::Str(name_attr_value) = derive_attr.lit {
-                        command_name = name_attr_value.value();
-                    } else {
-                        return syn::Error::new(
-                            derive_attr.lit.span(),
-                            "'name' attribute must be a string",
-                        )
-                        .to_compile_error()
-                        .into();
+        match attr_meta {
+            Meta::NameValue(derive_attr) => {
+                match derive_attr.path.get_ident().unwrap().to_string().as_str() {
+                    "name" => {
+                        if let Lit::Str(name_attr_value) = derive_attr.lit {
+                            command_name = name_attr_value.value();
+                        } else {
+                            return syn::Error::new(
+                                derive_attr.lit.span(),
+                                "'name' attribute must be a string",
+                            )
+                            .to_compile_error()
+                            .into();
+                        }
                     }
-                }
-                "description" => {
-                    if let Lit::Str(description_attr_value) = derive_attr.lit {
-                        description = description_attr_value.value();
-                    } else {
-                        return syn::Error::new(
-                            derive_attr.lit.span(),
-                            "'description' attribute must be a string",
-                        )
-                        .to_compile_error()
-                        .into();
+                    "description" => {
+                        if let Lit::Str(description_attr_value) = derive_attr.lit {
+                            description = description_attr_value.value();
+                        } else {
+                            return syn::Error::new(
+                                derive_attr.lit.span(),
+                                "'description' attribute must be a string",
+                            )
+                            .to_compile_error()
+                            .into();
+                        }
                     }
-                }
-                "deferred" => {
-                    if let Lit::Bool(deferred_attr_value) = derive_attr.lit {
-                        deferred = deferred_attr_value.value();
-                    } else {
-                        return syn::Error::new(
-                            derive_attr.lit.span(),
-                            "'deferred' attribute must be a bool",
-                        )
-                        .to_compile_error()
-                        .into();
+                    "deferred" => {
+                        if let Lit::Bool(deferred_attr_value) = derive_attr.lit {
+                            deferred = deferred_attr_value.value();
+                        } else {
+                            return syn::Error::new(
+                                derive_attr.lit.span(),
+                                "'deferred' attribute must be a bool",
+                            )
+                            .to_compile_error()
+                            .into();
+                        }
                     }
+                    _ => (),
                 }
-                _ => (),
             }
+            Meta::List(derive_attr_list) => {
+                if derive_attr_list
+                    .path
+                    .get_ident()
+                    .unwrap()
+                    .to_string()
+                    .as_str()
+                    == "argument"
+                {
+                    let mut name: Option<String> = None;
+                    let mut description: Option<String> = None;
+                    let mut kind: Option<String> = None;
+                    let mut required = true;
+
+                    for arguments_attr_meta in derive_attr_list.nested.iter() {
+                        if let NestedMeta::Meta(Meta::NameValue(argument_item)) =
+                            arguments_attr_meta
+                        {
+                            match argument_item.path.get_ident().unwrap().to_string().as_str() {
+                                    "name" => {
+                                        if let Lit::Str(argument_name) = argument_item.lit.to_owned() {
+                                            name = Some(argument_name.value());
+                                        } else {
+                                            return syn::Error::new(argument_item.lit.span(), "Name must be a string").to_compile_error().into()
+                                        }
+                                    }
+                                    "description" => {
+                                        if let Lit::Str(argument_description) = argument_item.lit.to_owned() {
+                                            description = Some(argument_description.value());
+                                        } else {
+                                            return syn::Error::new(argument_item.lit.span(), "Description must be a string").to_compile_error().into()
+                                        }
+                                    }
+                                    "kind" => {
+                                        if let Lit::Str(argument_kind) = argument_item.lit.to_owned() {
+                                            kind = Some(argument_kind.value());
+                                        } else {
+                                            return syn::Error::new(argument_item.lit.span(), "Kind must be a string").to_compile_error().into()
+                                        }
+                                    }
+                                    "required" => {
+                                        if let Lit::Bool(argument_required) = argument_item.lit.to_owned() {
+                                            required = argument_required.value();
+                                        }
+                                    }
+                                    _ => {
+                                        return syn::Error::new(argument_item.path.get_ident().unwrap().span(), "Only 'name', 'description', 'kind' and 'required' are supported")
+                                            .to_compile_error()
+                                            .into()
+                                    }
+                                }
+                        }
+                    }
+                    match (name, description, kind) {
+                        (Some(name), Some(description), Some(kind)) => {
+                            arguments.push((name, description, kind, required));
+                        }
+                        _ => {
+                            return syn::Error::new(
+                                derive_attr_list.path.get_ident().unwrap().span(),
+                                "You need to specify at least 'name', 'description' and 'kind'",
+                            )
+                            .to_compile_error()
+                            .into();
+                        }
+                    }
+                }
+            }
+            _ => (),
         }
     }
+    let argument_tokens = arguments.iter().map(|(name, description, kind, required)| {
+        let kind_token: proc_macro2::TokenStream = kind.parse().unwrap();
+        quote! {
+            __CadencyCommandOption {
+                name: #name,
+                description: #description,
+                kind: __CommandOptionType::#kind_token,
+                required: #required
+            }
+        }
+    });
     quote! {
-        use cadency_core::{self, CadencyCommandBaseline};
-        impl cadency_core::CadencyCommandBaseline for #struct_name {
+        use cadency_core::{CadencyCommandBaseline as __CadencyCommandBaseline, CadencyCommandOption as __CadencyCommandOption};
+        use serenity::model::application::command::CommandOptionType as __CommandOptionType;
+        impl __CadencyCommandBaseline for #struct_name {
             fn name(&self) -> String {
                 String::from(#command_name)
             }
@@ -65,8 +149,8 @@ pub(crate) fn impl_command_baseline(derive_input: DeriveInput) -> TokenStream {
                 #deferred
             }
 
-            fn options(&self) -> &Vec<CadencyCommandOption> {
-                self.options.as_ref()
+            fn options(&self) -> Vec<__CadencyCommandOption> {
+                vec![#(#argument_tokens),*]
             }
         }
     }

--- a/cadency_codegen/src/lib.rs
+++ b/cadency_codegen/src/lib.rs
@@ -6,7 +6,7 @@ use syn::{parse_macro_input, DeriveInput};
 
 mod derive;
 
-#[proc_macro_derive(CommandBaseline, attributes(name, description, deferred))]
+#[proc_macro_derive(CommandBaseline, attributes(name, description, deferred, argument))]
 pub fn derive_command_baseline(input_item: TokenStream) -> TokenStream {
     // Parse token stream into derive syntax tree
     let tree: DeriveInput = parse_macro_input!(input_item);

--- a/cadency_commands/src/fib.rs
+++ b/cadency_commands/src/fib.rs
@@ -1,34 +1,23 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait,
     client::Context,
-    model::application::{
-        command::CommandOptionType,
-        interaction::application_command::{ApplicationCommandInteraction, CommandDataOptionValue},
+    model::application::interaction::application_command::{
+        ApplicationCommandInteraction, CommandDataOptionValue,
     },
 };
 
-#[derive(CommandBaseline)]
+#[derive(CommandBaseline, Default)]
 #[description = "Calculate the nth number in the fibonacci sequence"]
-pub struct Fib {
-    options: Vec<CadencyCommandOption>,
-}
-
-impl std::default::Default for Fib {
-    fn default() -> Self {
-        Self {
-            options: vec![CadencyCommandOption {
-                name: "number",
-                description: "The number in the fibonacci sequence",
-                kind: CommandOptionType::Integer,
-                required: true,
-            }],
-        }
-    }
-}
+#[argument(
+    name = "number",
+    description = "The number in the fibonacci sequence",
+    kind = "Integer"
+)]
+pub struct Fib {}
 
 impl Fib {
     fn calc(n: &i64) -> f64 {

--- a/cadency_commands/src/inspire.rs
+++ b/cadency_commands/src/inspire.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    CadencyCommand, CadencyCommandOption, CadencyError,
+    CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -9,9 +9,7 @@ use serenity::{
 
 #[derive(CommandBaseline, Default)]
 #[description = "Say something really inspiring!"]
-pub struct Inspire {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Inspire {}
 
 impl Inspire {
     async fn request_inspire_image_url() -> Result<String, reqwest::Error> {

--- a/cadency_commands/src/lib.rs
+++ b/cadency_commands/src/lib.rs
@@ -32,14 +32,10 @@ pub use urban::Urban;
 
 #[cfg(test)]
 mod test {
-    use cadency_core::CadencyCommandOption;
-
     #[test]
     fn impl_commandbaseline_trait_with_macro() {
         #[derive(cadency_codegen::CommandBaseline)]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
+        struct Test {}
         assert!(true)
     }
 
@@ -47,12 +43,8 @@ mod test {
     fn return_lowercase_struct_name_as_name() {
         #[derive(cadency_codegen::CommandBaseline)]
         #[description = "123"]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
-        let test = Test {
-            options: Vec::new(),
-        };
+        struct Test {}
+        let test = Test {};
         let name: String = test.name();
         assert_eq!(name, "test", "Test command name to be lowercase {name}")
     }
@@ -62,12 +54,8 @@ mod test {
         #[derive(cadency_codegen::CommandBaseline)]
         #[name = "my_test"]
         #[description = "123"]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
-        let test = Test {
-            options: Vec::new(),
-        };
+        struct Test {}
+        let test = Test {};
         let name: String = test.name();
         assert_eq!(
             name, "my_test",
@@ -79,12 +67,8 @@ mod test {
     fn not_return_uppercase_struct_name_as_name() {
         #[derive(cadency_codegen::CommandBaseline)]
         #[description = "123"]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
-        let test = Test {
-            options: Vec::new(),
-        };
+        struct Test {}
+        let test = Test {};
         let name: String = test.name();
         assert_ne!(
             name, "Test",
@@ -96,12 +80,8 @@ mod test {
     fn return_attribute_description() {
         #[derive(cadency_codegen::CommandBaseline)]
         #[description = "123"]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
-        let test = Test {
-            options: Vec::new(),
-        };
+        struct Test {}
+        let test = Test {};
         assert_eq!(
             test.description(),
             "123",
@@ -113,12 +93,8 @@ mod test {
     fn return_default_deferred_config() {
         #[derive(cadency_codegen::CommandBaseline)]
         #[description = "123"]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
-        let test = Test {
-            options: Vec::new(),
-        };
+        struct Test {}
+        let test = Test {};
         assert_eq!(
             test.deferred(),
             false,
@@ -131,12 +107,70 @@ mod test {
         #[derive(cadency_codegen::CommandBaseline)]
         #[description = "123"]
         #[deferred = true]
-        struct Test {
-            options: Vec<CadencyCommandOption>,
-        }
-        let test = Test {
-            options: Vec::new(),
-        };
+        struct Test {}
+        let test = Test {};
         assert!(test.deferred(), "Test command should be deferred")
+    }
+
+    #[test]
+    fn return_empty_options_by_default() {
+        #[derive(cadency_codegen::CommandBaseline)]
+        struct Test {}
+        let test = Test {};
+        assert_eq!(test.options().len(), 0);
+    }
+
+    #[test]
+    fn return_derived_option() {
+        use serenity::model::application::command::CommandOptionType;
+        #[derive(cadency_codegen::CommandBaseline)]
+        #[argument(
+            name = "say",
+            description = "Word to say",
+            kind = "String",
+            required = false
+        )]
+        struct Test {}
+        let test = Test {};
+        let arguments = test.options();
+        assert_eq!(arguments.len(), 1);
+        let argument = arguments.get(0).unwrap();
+        assert_eq!(argument.name, "say");
+        assert_eq!(argument.description, "Word to say");
+        assert_eq!(argument.kind, CommandOptionType::String);
+        assert_eq!(argument.required, false);
+    }
+
+    #[test]
+    fn return_required_option_by_default() {
+        #[derive(cadency_codegen::CommandBaseline)]
+        #[argument(name = "say", description = "Word to say", kind = "String")]
+        struct Test {}
+        let test = Test {};
+        let arguments = test.options();
+        assert_eq!(arguments.len(), 1);
+        let argument = arguments.get(0).unwrap();
+        assert!(argument.required);
+    }
+
+    #[test]
+    fn return_multiple_options() {
+        use serenity::model::application::command::CommandOptionType;
+
+        #[derive(cadency_codegen::CommandBaseline)]
+        #[argument(name = "say", description = "Word to say", kind = "String")]
+        #[argument(name = "target", description = "The target user", kind = "User")]
+        struct Test {}
+        let test = Test {};
+        let arguments = test.options();
+        assert_eq!(arguments.len(), 2);
+        let first_argument = arguments.get(0).unwrap();
+        let second_argument = arguments.get(1).unwrap();
+        assert_eq!(first_argument.name, "say");
+        assert_eq!(first_argument.description, "Word to say");
+        assert_eq!(first_argument.kind, CommandOptionType::String);
+        assert_eq!(second_argument.name, "target");
+        assert_eq!(second_argument.description, "The target user");
+        assert_eq!(second_argument.kind, CommandOptionType::User);
     }
 }

--- a/cadency_commands/src/now.rs
+++ b/cadency_commands/src/now.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -9,9 +9,7 @@ use serenity::{
 
 #[derive(CommandBaseline, Default)]
 #[description = "Shows current song"]
-pub struct Now {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Now {}
 
 #[async_trait]
 impl CadencyCommand for Now {

--- a/cadency_commands/src/pause.rs
+++ b/cadency_commands/src/pause.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -10,9 +10,7 @@ use serenity::{
 #[derive(CommandBaseline, Default)]
 #[description = "Pause the current song"]
 #[deferred = true]
-pub struct Pause {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Pause {}
 
 #[async_trait]
 impl CadencyCommand for Pause {

--- a/cadency_commands/src/ping.rs
+++ b/cadency_commands/src/ping.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    CadencyCommand, CadencyCommandOption, CadencyError,
+    CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -9,9 +9,7 @@ use serenity::{
 
 #[derive(CommandBaseline, Default)]
 #[description = "Play Ping-Pong"]
-pub struct Ping {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Ping {}
 
 #[async_trait]
 impl CadencyCommand for Ping {

--- a/cadency_commands/src/play.rs
+++ b/cadency_commands/src/play.rs
@@ -1,38 +1,27 @@
 use cadency_core::{
     handler::voice::InactiveHandler,
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use reqwest::Url;
 use serenity::{
     async_trait,
     client::Context,
-    model::application::{
-        command::CommandOptionType,
-        interaction::application_command::{ApplicationCommandInteraction, CommandDataOptionValue},
+    model::application::interaction::application_command::{
+        ApplicationCommandInteraction, CommandDataOptionValue,
     },
 };
 use songbird::events::Event;
 
-#[derive(CommandBaseline)]
+#[derive(CommandBaseline, Default)]
 #[description = "Play a song from Youtube"]
 #[deferred = true]
-pub struct Play {
-    options: Vec<CadencyCommandOption>,
-}
-
-impl std::default::Default for Play {
-    fn default() -> Self {
-        Self {
-            options: vec![CadencyCommandOption {
-                name: "query",
-                description: "URL or search query like: 'Hey Jude Beatles'",
-                kind: CommandOptionType::String,
-                required: true,
-            }],
-        }
-    }
-}
+#[argument(
+    name = "quiery",
+    description = "URL or search query like: 'Hey Jude Beatles'",
+    kind = "String"
+)]
+pub struct Play {}
 
 #[async_trait]
 impl CadencyCommand for Play {

--- a/cadency_commands/src/resume.rs
+++ b/cadency_commands/src/resume.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -10,9 +10,7 @@ use serenity::{
 #[derive(CommandBaseline, Default)]
 #[description = "Resume current song if paused"]
 #[deferred = true]
-pub struct Resume {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Resume {}
 
 #[async_trait]
 impl CadencyCommand for Resume {

--- a/cadency_commands/src/skip.rs
+++ b/cadency_commands/src/skip.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -10,9 +10,7 @@ use serenity::{
 #[derive(CommandBaseline, Default)]
 #[description = "Skip current song"]
 #[deferred = true]
-pub struct Skip {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Skip {}
 
 #[async_trait]
 impl CadencyCommand for Skip {

--- a/cadency_commands/src/slap.rs
+++ b/cadency_commands/src/slap.rs
@@ -1,34 +1,23 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait,
     client::Context,
-    model::application::{
-        command::CommandOptionType,
-        interaction::application_command::{ApplicationCommandInteraction, CommandDataOptionValue},
+    model::application::interaction::application_command::{
+        ApplicationCommandInteraction, CommandDataOptionValue,
     },
 };
 
-#[derive(CommandBaseline)]
+#[derive(CommandBaseline, Default)]
 #[description = "Slap someone with a large trout!"]
-pub struct Slap {
-    options: Vec<CadencyCommandOption>,
-}
-
-impl std::default::Default for Slap {
-    fn default() -> Self {
-        Self {
-            options: vec![CadencyCommandOption {
-                name: "target",
-                description: "The user you want to slap",
-                kind: CommandOptionType::User,
-                required: true,
-            }],
-        }
-    }
-}
+#[argument(
+    name = "target",
+    description = "The user you want to slap",
+    kind = "User"
+)]
+pub struct Slap {}
 
 #[async_trait]
 impl CadencyCommand for Slap {

--- a/cadency_commands/src/stop.rs
+++ b/cadency_commands/src/stop.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, client::Context,
@@ -10,9 +10,7 @@ use serenity::{
 #[derive(CommandBaseline, Default)]
 #[description = "Stop music and clear the track list"]
 #[deferred = true]
-pub struct Stop {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Stop {}
 
 #[async_trait]
 impl CadencyCommand for Stop {

--- a/cadency_commands/src/tracks.rs
+++ b/cadency_commands/src/tracks.rs
@@ -1,6 +1,6 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait, builder::CreateEmbed, client::Context,
@@ -11,9 +11,7 @@ use serenity::{
 #[derive(CommandBaseline, Default)]
 #[description = "List all tracks in the queue"]
 #[deferred = true]
-pub struct Tracks {
-    options: Vec<CadencyCommandOption>,
-}
+pub struct Tracks {}
 
 #[async_trait]
 impl CadencyCommand for Tracks {

--- a/cadency_commands/src/urban.rs
+++ b/cadency_commands/src/urban.rs
@@ -1,14 +1,13 @@
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    utils, CadencyCommand, CadencyCommandOption, CadencyError,
+    utils, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait,
     builder::CreateEmbed,
     client::Context,
-    model::application::{
-        command::CommandOptionType,
-        interaction::application_command::{ApplicationCommandInteraction, CommandDataOptionValue},
+    model::application::interaction::application_command::{
+        ApplicationCommandInteraction, CommandDataOptionValue,
     },
     utils::Color,
 };
@@ -32,25 +31,11 @@ struct UrbanResult {
     pub list: Vec<UrbanEntry>,
 }
 
-#[derive(CommandBaseline)]
+#[derive(CommandBaseline, Default)]
 #[description = "Searches the Urbandictionary for your query"]
 #[deferred = true]
-pub struct Urban {
-    options: Vec<CadencyCommandOption>,
-}
-
-impl std::default::Default for Urban {
-    fn default() -> Self {
-        Self {
-            options: vec![CadencyCommandOption {
-                name: "query",
-                description: "Your search query",
-                kind: CommandOptionType::String,
-                required: true,
-            }],
-        }
-    }
-}
+#[argument(name = "query", description = "Your search query", kind = "String")]
+pub struct Urban {}
 
 impl Urban {
     async fn request_urban_dictionary_entries(

--- a/cadency_core/src/command.rs
+++ b/cadency_core/src/command.rs
@@ -37,7 +37,7 @@ pub trait CadencyCommandBaseline {
     fn name(&self) -> String;
     fn description(&self) -> String;
     fn deferred(&self) -> bool;
-    fn options(&self) -> &Vec<CadencyCommandOption>;
+    fn options(&self) -> Vec<CadencyCommandOption>;
 }
 
 pub struct CadencyCommandOption {

--- a/examples/custom_commands/examples/custom_commands.rs
+++ b/examples/custom_commands/examples/custom_commands.rs
@@ -6,37 +6,21 @@ extern crate cadency_codegen;
 use cadency_commands::Fib;
 use cadency_core::{
     response::{Response, ResponseBuilder},
-    setup_commands, utils, Cadency, CadencyCommand, CadencyCommandOption, CadencyError,
+    setup_commands, utils, Cadency, CadencyCommand, CadencyError,
 };
 use serenity::{
     async_trait,
     client::Context,
-    model::application::{
-        command::CommandOptionType,
-        interaction::application_command::{ApplicationCommandInteraction, CommandDataOptionValue},
+    model::application::interaction::application_command::{
+        ApplicationCommandInteraction, CommandDataOptionValue,
     },
 };
 
 // This is your custom command with the name "hello"
-#[derive(CommandBaseline)]
+#[derive(CommandBaseline, Default)]
 #[description = "Say Hello to a user"]
-struct Hello {
-    // The allowed list of command arguments
-    options: Vec<CadencyCommandOption>,
-}
-
-impl std::default::Default for Hello {
-    fn default() -> Self {
-        Self {
-            options: vec![CadencyCommandOption {
-                name: "user",
-                description: "The user to greet",
-                kind: CommandOptionType::User,
-                required: true,
-            }],
-        }
-    }
-}
+#[argument(name = "user", description = "The user to great", kind = "User")]
+struct Hello {}
 
 #[async_trait]
 impl CadencyCommand for Hello {


### PR DESCRIPTION
This PR adds an `argument` helper attribute to the `CommandBaseline` derive macro to reduce the boilerplate code to create a command with arguments.