### PR TITLE
Opt-in to use rustls-tls instead open-ssl in reqwest library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ members = [
 [workspace.dependencies]
 env_logger = "0.10.0"
 log = "0.4.17"
-reqwest = "0.11.14"
 thiserror = "1.0.38"
 serde_json = "1.0.91"
 derive_builder = "0.12.0"
@@ -32,3 +31,8 @@ features = ["macros", "rt-multi-thread"]
 [workspace.dependencies.serde]
 version = "1.0.152"
 features = ["derive"]
+
+[workspace.dependencies.reqwest]
+version = "0.11.14"
+default-features = false
+features = ["rustls-tls"]


### PR DESCRIPTION
Removes the openssl dependency of the reqwest library and will make cross compiling and multi platform builds easier.
