### PR TITLE
Release v0.5.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(dev-deps)"      
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ serde_json = "1.0.99"
 derive_builder = "0.20.0"
 
 [workspace.dependencies.serenity]
-version = "0.12.0"
+version = "0.12.1"
 default-features = false
 features = ["client", "gateway", "rustls_backend", "model", "voice", "cache"]
 
 [workspace.dependencies.songbird]
-version = "0.4.0"
+version = "0.4.1"
 features = ["builtin-queue"]
 
 [workspace.dependencies.tokio]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ version = "1.0.197"
 features = ["derive"]
 
 [workspace.dependencies.reqwest]
-version = "0.11.18"
+version = "0.11.27"
 default-features = false
 features = ["rustls-tls", "json"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ resolver = "2"
 [workspace.dependencies]
 env_logger = "0.11.3"
 log = "0.4.21"
-thiserror = "1.0.58"
-serde_json = "1.0.115"
+thiserror = "1.0.59"
+serde_json = "1.0.116"
 derive_builder = "0.20.0"
 
 [workspace.dependencies.serenity]
@@ -30,7 +30,7 @@ version = "1.37.0"
 features = ["macros", "rt-multi-thread"]
 
 [workspace.dependencies.serde]
-version = "1.0.197"
+version = "1.0.198"
 features = ["derive"]
 
 [workspace.dependencies.reqwest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-env_logger = "0.11.0"
-log = "0.4.19"
+env_logger = "0.11.3"
+log = "0.4.21"
 thiserror = "1.0.40"
 serde_json = "1.0.99"
 derive_builder = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "0.4.1"
 features = ["builtin-queue"]
 
 [workspace.dependencies.tokio]
-version = "1.29.0"
+version = "1.37.0"
 features = ["macros", "rt-multi-thread"]
 
 [workspace.dependencies.serde]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 env_logger = "0.11.3"
 log = "0.4.21"
 thiserror = "1.0.58"
-serde_json = "1.0.99"
+serde_json = "1.0.115"
 derive_builder = "0.20.0"
 
 [workspace.dependencies.serenity]
@@ -30,7 +30,7 @@ version = "1.29.0"
 features = ["macros", "rt-multi-thread"]
 
 [workspace.dependencies.serde]
-version = "1.0.164"
+version = "1.0.197"
 features = ["derive"]
 
 [workspace.dependencies.reqwest]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.dependencies]
 env_logger = "0.11.3"
 log = "0.4.21"
-thiserror = "1.0.40"
+thiserror = "1.0.58"
 serde_json = "1.0.99"
 derive_builder = "0.20.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ default-features = false
 features = ["rustls-tls", "json"]
 
 [workspace.dependencies.symphonia]
-version = "0.5"
+version = "0.5.4"
 features = ["all-formats"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.75-slim-bullseye as build_base
+FROM lukemathwalker/cargo-chef:latest-rust-1.77-slim-bullseye as build_base
 
 FROM build_base as planner
 WORKDIR /cadency

--- a/cadency_codegen/Cargo.toml
+++ b/cadency_codegen/Cargo.toml
@@ -12,6 +12,6 @@ proc_macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.63"
-quote = "1.0.28"
-syn = "2.0.22"
+proc-macro2 = "1.0.79"
+quote = "1.0.35"
+syn = "2.0.58"

--- a/cadency_codegen/Cargo.toml
+++ b/cadency_codegen/Cargo.toml
@@ -12,6 +12,6 @@ proc_macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.79"
-quote = "1.0.35"
-syn = "2.0.58"
+proc-macro2 = "1.0.81"
+quote = "1.0.36"
+syn = "2.0.60"


### PR DESCRIPTION
- **fix(deps): Update songbird and serentiy (`0.4.1` & `0.12.1`)**
- **fix(deps): Update log `0.4.21` and env_logger `0.11.3`**
- **fix(deps): Update thiserror to `1.0.58`**
- **fix(deps): Update serde `1.0.197` and serde_json `1.0.115`**
- **fix(deps): Pin symphonia on patch version `0.5.4`**
- **fix(deps): Update tokio runtime to `1.37.0`**
- **fix(deps): Update code generation dependencies**
- **fix(deps): Update reqwest to `0.11.27`**
- **chore(github): Adjust dependabot config to use `fix` prefix on prod deps**
- **fix(deps): Update several dependencies**
- **chore(docker): Update use rust version in dockerfile**


Close #144 