### PR TITLE
Allow commands to be registered in a guild instead of globally

### DIFF
--- a/cadency_core/src/client.rs
+++ b/cadency_core/src/client.rs
@@ -1,6 +1,10 @@
 use crate::{
-    command::Commands, error::CadencyError, handler::command::Handler, http::HttpClientKey,
-    intents::CadencyIntents, CadencyCommand,
+    command::{Commands, CommandsScope},
+    error::CadencyError,
+    handler::command::Handler,
+    http::HttpClientKey,
+    intents::CadencyIntents,
+    CadencyCommand,
 };
 use serenity::{client::Client, model::gateway::GatewayIntents};
 use songbird::SerenityInit;
@@ -13,6 +17,9 @@ pub struct Cadency {
     commands: Vec<Arc<dyn CadencyCommand>>,
     #[builder(default = "CadencyIntents::default().into()")]
     intents: GatewayIntents,
+    /// Used when registering commands with the Discord API
+    #[builder(default)]
+    commands_scope: CommandsScope,
 }
 
 impl Cadency {
@@ -28,6 +35,7 @@ impl Cadency {
             .register_songbird()
             .type_map_insert::<Commands>(self.commands)
             .type_map_insert::<HttpClientKey>(reqwest::Client::new())
+            .type_map_insert::<CommandsScope>(self.commands_scope)
             .await
             .map_err(|err| CadencyError::Start { source: err })?;
         client

--- a/cadency_core/src/lib.rs
+++ b/cadency_core/src/lib.rs
@@ -5,7 +5,7 @@ extern crate serenity;
 pub mod client;
 pub use client::Cadency;
 mod command;
-pub use command::{CadencyCommand, CadencyCommandBaseline, CadencyCommandOption};
+pub use command::{CadencyCommand, CadencyCommandBaseline, CadencyCommandOption, CommandsScope};
 mod error;
 pub use error::CadencyError;
 pub mod handler;

--- a/cadency_core/src/utils/mod.rs
+++ b/cadency_core/src/utils/mod.rs
@@ -1,4 +1,7 @@
-use crate::{command::Commands, CadencyCommand};
+use crate::{
+    command::{Commands, CommandsScope},
+    CadencyCommand,
+};
 use serenity::client::Context;
 use std::sync::Arc;
 
@@ -9,5 +12,13 @@ pub(crate) async fn get_commands(ctx: &Context) -> Vec<Arc<dyn CadencyCommand>> 
     data_read
         .get::<Commands>()
         .expect("Command array missing")
+        .clone()
+}
+
+pub(crate) async fn get_commands_scope(ctx: &Context) -> CommandsScope {
+    let data_read = ctx.data.read().await;
+    data_read
+        .get::<CommandsScope>()
+        .expect("Commands scope missing")
         .clone()
 }


### PR DESCRIPTION
Hello,

Thank you for your crate, it's great.

While trying it out I faced a small issue, I mainly develop and maintain a Discord Bot for my own Discord server, as such I wanted to register the commands only for my guild, not as global (especially when testing)

I added a small configuration enum to the client builder, which is then used when registering the commands, to do so globally or only for a guild. 

If the feature or the implementation does not suit you, feel free to close the PR !