### PR TITLE
Disable semantic commit title check

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,5 +1,5 @@
 ---
-titleAndCommits: true
+titleAndCommits: false
 types:
   - feat
   - fix


### PR DESCRIPTION
This PR disables the check for semantic PR titles. As PRs are not squashed, this is not required.