### PR TITLE
Upgrade rust version to `1.81.0`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,15 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "fix(deps)"
-      prefix-development: "chore(dev-deps)"      
+      prefix-development: "chore(dev-deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "docker"
+    directory: /
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(dev-deps)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.77-slim-bullseye as build_base
+FROM lukemathwalker/cargo-chef:latest-rust-1.81.0-slim-bullseye as build_base
 
 FROM build_base as planner
 WORKDIR /cadency

--- a/cadency_codegen/Cargo.toml
+++ b/cadency_codegen/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/jontze/cadency-rs"
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/cadency_commands/src/lib.rs
+++ b/cadency_commands/src/lib.rs
@@ -38,6 +38,7 @@ pub use roll::Roll;
 mod test {
     #[test]
     fn impl_commandbaseline_trait_with_macro() {
+        #[allow(dead_code)]
         #[derive(cadency_codegen::CommandBaseline)]
         struct Test {}
     }
@@ -140,7 +141,7 @@ mod test {
         let test = Test {};
         let arguments = test.options();
         assert_eq!(arguments.len(), 1);
-        let argument = arguments.get(0).unwrap();
+        let argument = arguments.first().unwrap();
         assert_eq!(argument.name, "say");
         assert_eq!(argument.description, "Word to say");
         assert_eq!(argument.kind, CommandOptionType::String);
@@ -160,7 +161,7 @@ mod test {
             "Command should have 1 argument, but had {}",
             amount_of_arguments
         );
-        let argument = arguments.get(0).unwrap();
+        let argument = arguments.first().unwrap();
         assert!(argument.required, "Command argument should be required");
     }
 
@@ -175,7 +176,7 @@ mod test {
         let test = Test {};
         let arguments = test.options();
         assert_eq!(arguments.len(), 2);
-        let first_argument = arguments.get(0).unwrap();
+        let first_argument = arguments.first().unwrap();
         let second_argument = arguments.get(1).unwrap();
         assert_eq!(first_argument.name, "say");
         assert_eq!(first_argument.description, "Word to say");

--- a/cadency_commands/src/track_loop.rs
+++ b/cadency_commands/src/track_loop.rs
@@ -13,6 +13,7 @@ use serenity::{async_trait, client::Context, model::application::CommandInteract
     required = false,
     kind = "Integer"
 )]
+#[allow(clippy::duplicated_attributes)]
 #[argument(
     name = "stop",
     description = "Cancel looping",

--- a/cadency_commands/src/urban.rs
+++ b/cadency_commands/src/urban.rs
@@ -51,14 +51,14 @@ impl Urban {
             }
             let embed_urban_entry = CreateEmbed::default()
                 .color(Color::from_rgb(255, 255, 0))
-                .title(&urban.word.replace(['[', ']'], ""))
+                .title(urban.word.replace(['[', ']'], ""))
                 .url(&urban.permalink)
                 .field(
                     "Definition",
-                    &urban.definition.replace(['[', ']'], ""),
+                    urban.definition.replace(['[', ']'], ""),
                     false,
                 )
-                .field("Example", &urban.example.replace(['[', ']'], ""), false)
+                .field("Example", urban.example.replace(['[', ']'], ""), false)
                 .field(
                     "Rating",
                     format!(

--- a/cadency_core/src/utils/mod.rs
+++ b/cadency_core/src/utils/mod.rs
@@ -17,8 +17,7 @@ pub(crate) async fn get_commands(ctx: &Context) -> Vec<Arc<dyn CadencyCommand>> 
 
 pub(crate) async fn get_commands_scope(ctx: &Context) -> CommandsScope {
     let data_read = ctx.data.read().await;
-    data_read
+    *data_read
         .get::<CommandsScope>()
         .expect("Commands scope missing")
-        .clone()
 }


### PR DESCRIPTION
This PR upgrades the Rust Version to v1.81.0 and adjusts some code to suppress new clippy warnings.