### PR TITLE
fix(docker): Upgrade debian runtime to bookworm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.81.0-slim-bookworm as build_base
+FROM lukemathwalker/cargo-chef:latest-rust-1.81.0-slim-bookworm AS build_base
 
-FROM build_base as planner
+FROM build_base AS planner
 WORKDIR /cadency
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM build_base as cacher
+FROM build_base AS cacher
 WORKDIR /cadency
 COPY --from=planner /cadency/recipe.json recipe.json
 ENV RUSTUP_MAX_RETRIES=100
 ENV CARGO_INCREMENTAL=0
 ENV CARGO_NET_RETRY=100
 ENV CARGO_TERM_COLOR=always
-RUN apt-get update && apt-get install -y cmake && apt-get autoremove -y
 # Build dependencies - this is the dependencies caching layer
 RUN cargo chef cook --release --recipe-path recipe.json 
 
-FROM build_base as builder
+FROM build_base AS builder
 WORKDIR /cadency
 COPY . .
 COPY --from=cacher /cadency/target target
@@ -29,16 +28,17 @@ ENV CARGO_TERM_COLOR=always
 RUN cargo build --release --bin cadency
 
 # Downloads yt-dlp
-FROM bitnami/minideb:bookworm as packages
+FROM bitnami/minideb:bookworm AS packages
 WORKDIR /packages
 COPY --from=builder /cadency/.yt-dlprc .
 RUN YTDLP_VERSION=$(cat .yt-dlprc) && \
   apt-get update && apt-get install -y curl && \
-  curl -L https://github.com/yt-dlp/yt-dlp/releases/download/$YTDLP_VERSION/yt-dlp_linux > yt-dlp && chmod +x yt-dlp
+  curl -L https://github.com/yt-dlp/yt-dlp/releases/download/$YTDLP_VERSION/yt-dlp_linux > yt-dlp && \
+  chmod +x yt-dlp
 
 # Based on: https://github.com/zarmory/docker-python-minimal/blob/master/Dockerfile
 # Removes Python build and developmenttools like pip.
-FROM bitnami/minideb:bullseye as python-builder
+FROM bitnami/minideb:bookworm AS python-builder
 RUN apt-get update && apt-get install -y python3-minimal binutils && \
   rm -rf /usr/local/lib/python*/ensurepip && \
   rm -rf /usr/local/lib/python*/idlelib && \
@@ -48,7 +48,7 @@ RUN apt-get update && apt-get install -y python3-minimal binutils && \
   find /usr/local/bin -not -name 'python*' \( -type f -o -type l \) -exec rm {} \;&& \
   rm -rf /usr/local/share/*
 
-FROM bitnami/minideb:bullseye as runtime
+FROM bitnami/minideb:bookworm AS runtime
 LABEL org.opencontainers.image.source="https://github.com/jontze/cadency-rs"
 WORKDIR /cadency
 COPY --from=builder /cadency/target/release/cadency cadency


### PR DESCRIPTION
This should fix the glibc error due to the debian version miss-match between the docker build and runtime.